### PR TITLE
Nissix plugin scope-packages on ambassador-conflict

### DIFF
--- a/serverless/ambassador-conflict/package.json
+++ b/serverless/ambassador-conflict/package.json
@@ -6,7 +6,7 @@
     "test": "DEBUG='wix:*' jest"
   },
   "dependencies": {
-    "ambassador-conflict-test": "1.0.0"
+    "@wix/ambassador-conflict-test": "1.0.0"
   },
   "devDependencies": {
     "@wix/ambassador-wix-meta-site-manager-webapp": "^2.0.84",

--- a/serverless/ambassador-conflict/serverless.js
+++ b/serverless/ambassador-conflict/serverless.js
@@ -1,4 +1,4 @@
-const {getUserSites} = require('ambassador-conflict-test');
+const {getUserSites} = require('@wix/ambassador-conflict-test');
 
 
 module.exports = (functionsBuilder) => functionsBuilder


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.135s



Output Log:
Migrating package "ambassador-conflict" in serverless/ambassador-conflict


## Migration from non scope to @wix/scoped packages
> /tmp/4c59206921a6e6edcae5623c06b1e660/serverless/ambassador-conflict

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
serverless.js
```

